### PR TITLE
fix font family property by unquoting the value, fixes #2

### DIFF
--- a/src/dialog-typography.scss
+++ b/src/dialog-typography.scss
@@ -6,7 +6,7 @@ $dialog-typo: (
   desktop: (
     default: (
       font-size         : 1.125rem,
-      font-family       : sans-serif,
+      font-family       : '"Helvetica Neue", Helvetica, Arial, sans-serif',
       font-weight       : normal,
       font-style        : normal,
       line-height       : 1.375,
@@ -285,6 +285,8 @@ $dialog-fluid-type-sizes: ();
     @each $property, $value in $breakpoint-styles {
       @if $dialog-is-fluid and ($property == 'font-size')  {
         @include poly-fluid-sizing('font-size', map-get($dialog-fluid-type-sizes, $name));
+      } @else if $property == 'font-family' {
+        #{$property}: unquote($value);
       } @else {
         #{$property}: $value;
       }


### PR DESCRIPTION
Hi, one of the project I was working on was using this library, and our team had issues with the `font-family` rule breaking as well. We found the fix for it, by `unquote`-ing the `$value` of `font-family` property. I am not completely sure if it fixes the issue, so I hope you will give it a look.

Thanks!